### PR TITLE
Add initial Vitest test for cn utility

### DIFF
--- a/package.json
+++ b/package.json
@@ -8,7 +8,8 @@
     "build": "vite build",
     "build:dev": "vite build --mode development",
     "lint": "eslint .",
-    "preview": "vite preview"
+    "preview": "vite preview",
+    "test": "vitest"
   },
   "dependencies": {
     "@hookform/resolvers": "^3.9.0",

--- a/src/__tests__/utils.test.ts
+++ b/src/__tests__/utils.test.ts
@@ -1,0 +1,18 @@
+import { describe, it, expect } from 'vitest'
+import { cn } from '../lib/utils'
+
+// Tests for the cn utility
+
+describe('cn', () => {
+  it('merges class names', () => {
+    expect(cn('foo', 'bar')).toBe('foo bar')
+  })
+
+  it('handles conditional arguments', () => {
+    expect(cn('foo', { bar: true, baz: false })).toBe('foo bar')
+  })
+
+  it('merges conflicting tailwind classes', () => {
+    expect(cn('p-2', 'p-4')).toBe('p-4')
+  })
+})


### PR DESCRIPTION
## Summary
- add `src/__tests__/utils.test.ts` with Vitest tests for `cn`
- expose `test` npm script

## Testing
- `bun run test` *(fails: `vitest` command not found)*

------
https://chatgpt.com/codex/tasks/task_e_687bbd5a0974832da0dde125b1317116