### PR TITLE
Fix AccessCodesPage hooks import

### DIFF
--- a/src/pages/access-codes/AccessCodesPage.tsx
+++ b/src/pages/access-codes/AccessCodesPage.tsx
@@ -1,5 +1,5 @@
 // src/pages/access-codes/AccessCodesPage.tsx
-import { useState } from "react";
+import { useState, useEffect } from "react";
 import { Link } from "react-router-dom";
 import { useTranslation } from "@/hooks/use-translation";
 import { useAuth } from "@/contexts/AuthContext";


### PR DESCRIPTION
## Summary
- import both `useState` and `useEffect` in `AccessCodesPage`

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*

------
https://chatgpt.com/codex/tasks/task_e_687bbd588a60832d86d2914d1aa28aff