### PR TITLE
Fix search term variable in access codes message

### DIFF
--- a/src/pages/access-codes/AccessCodesPage.tsx
+++ b/src/pages/access-codes/AccessCodesPage.tsx
@@ -119,7 +119,7 @@ export default function AccessCodesPage() {
               <Building className="mx-auto h-12 w-12 text-muted-foreground" />
               <h3 className="mt-2 text-lg font-semibold">No access codes found</h3>
               <p className="text-muted-foreground">
-                {searchQuery ? "Try adjusting your search terms" : "Add an access code to get started"}
+                {searchTerm ? "Try adjusting your search terms" : "Add an access code to get started"}
               </p>
             </div>
           ) : (


### PR DESCRIPTION
## Summary
- replace `searchQuery` with `searchTerm` in the access codes page so the message uses the correct state variable

## Testing
- `npx tsc --noEmit` *(fails: none)*
- `npm run lint` *(fails: cannot find package '@eslint/js')*

------
https://chatgpt.com/codex/tasks/task_e_687bbd4205e8832d97a7c001457da4e1